### PR TITLE
fix volume +-  buttons

### DIFF
--- a/plugin/src/ios/DBMeter.swift
+++ b/plugin/src/ios/DBMeter.swift
@@ -71,7 +71,7 @@ import AVFoundation
 
                 do {
                     let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
-                    try audioSession.setCategory(AVAudioSessionCategoryRecord)
+                    try audioSession.setCategory(AVAudioSessionCategoryPlayAndRecord)
                     try audioSession.setActive(true)
 
                     self.audioRecorder = try AVAudioRecorder(url: url, settings: settings)


### PR DESCRIPTION
The category set on audioSession made volume buttons unusable once the start function was called